### PR TITLE
Debug recurring command execution issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Run tests
       working-directory: testing/build
       run: |
-        ./stevensStringLibTest --gtest_output=xml:test_results.xml --gtest_color=yes
+        ./testStevensStringLib --gtest_output=xml:test_results.xml --gtest_color=yes
 
     - name: Generate coverage report
       if: matrix.build_type == 'Debug' && matrix.compiler == 'g++-11'
@@ -99,7 +99,7 @@ jobs:
       run: |
         ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1 \
         UBSAN_OPTIONS=print_stacktrace=1 \
-        ./stevensStringLibTest --gtest_color=yes
+        ./testStevensStringLib --gtest_color=yes
 
   # ============================================================================
   # Benchmarks


### PR DESCRIPTION
The CI workflow was using the wrong test executable name 'stevensStringLibTest' instead of 'testStevensStringLib', causing the unit tests and sanitizer jobs to fail.

Fixed in both:
- Unit test job (line 46)
- Sanitizer test job (line 102)